### PR TITLE
Associate match with first day

### DIFF
--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -7,7 +7,7 @@ class Calendar < ApplicationRecord
   validates :name, presence: true
 
   def find_or_create_day_for(datetime)
-    existing_day = days.find do |day|
+    existing_day = days.order(:id).find do |day|
       day.period_start_date <= datetime && day.period_end_date >= datetime
     end
 

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -142,6 +142,31 @@ RSpec.describe Match do
     it { expect(match.day.name).to eq('Week 2023-09-11 2023-09-17') }
   end
 
+  describe '#ffhb_sync! with several days on same period' do
+    let(:day1) { create(:day, period_start_date: '2023-09-11', period_end_date: '2023-09-17', calendar: match.championship.calendar) }
+    let(:day2) { create(:day, period_start_date: '2023-09-11', period_end_date: '2023-09-17', calendar: match.championship.calendar) }
+
+    let(:match) do
+      create(:match,
+             ffhb_key: '16-ans-m-2-eme-division-territoriale-94-75-23229 128335 1891863',
+             start_datetime: nil,
+             meeting_datetime: nil)
+    end
+
+    before do
+      mock_ffhb
+      # initialize day1 before day2 and before the match, so day1 is the first day
+      day1
+      match.update!(day: day2)
+    end
+
+    it 'associate the match with the first day' do
+      match.ffhb_sync!
+      match.reload
+      expect(match.day.id).to eq(day1.id)
+    end
+  end
+
   describe '#aways' do
     context 'with a player sick' do
       let(:section) { create(:section) }


### PR DESCRIPTION
This pull request includes changes to improve the handling of day associations in the `Calendar` model and adds a new test case to ensure the correct day is associated with a match when multiple days have the same period.

Improvements to day association:

* [`app/models/calendar.rb`](diffhunk://#diff-bfa26b528ddb1923a09639afa3d04bed71a1dd2f710725bed58282801626ea2eL10-R10): Modified the `find_or_create_day_for` method to order days by `id` before finding the existing day, ensuring a consistent selection when multiple days cover the same period.

Testing enhancements:

* [`spec/models/match_spec.rb`](diffhunk://#diff-0cb9833f2cbe0dc18818ea41e564f72cfeda29a0b611d2b191d5aa0e4a272239R145-R169): Added a new test case to verify that the `ffhb_sync!` method correctly associates a match with the first day when multiple days have the same period. This ensures robustness in day selection logic.