### PR TITLE
fix houdci config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,3 @@
-ruby:
+rubocop:
   config_file: .rubocop.yml
+  version: 1.22.1


### PR DESCRIPTION
This pull request includes a small change to the `.hound.yml` file. The change updates the configuration to use `rubocop` instead of `ruby` and specifies the version of `rubocop` to be used.

* [`.hound.yml`](diffhunk://#diff-5642a3862b74893248f41434119a2307f24bd32aa21f6b8de2a87771ccd10f42L1-R3): Changed configuration from `ruby` to `rubocop` and added the `version` attribute.