### PR TITLE
Security: enforce section membership globally (IDOR fix, part 1)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
   before_action :set_current_section_in_current
   before_action :authenticate_user_from_token!, except: :catch404
   before_action :authenticate_user!, except: :catch404
+  before_action :verify_user_member_of_section, except: :catch404
 
   helper_method :current_section, :origin_path_or
 
@@ -111,7 +112,10 @@ class ApplicationController < ActionController::Base
   end
 
   def verify_user_member_of_section
-    return unless current_section && !current_user.member_of?(current_section)
+    return if current_section.blank?
+    return if current_user&.member_of?(current_section)
+    return if current_user&.admin_of?(current_section.club)
+    return if current_user&.super_admin?
 
     respond_to do |format|
       format.html { render(file: Rails.public_path.join('403.html'), status: :forbidden, layout: false) }

--- a/app/controllers/duty_tasks_controller.rb
+++ b/app/controllers/duty_tasks_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class DutyTasksController < ApplicationController
-  before_action :verify_user_member_of_section
-
   def index
     @duty_tasks = task_scope.order(realised_at: :desc).page(params[:page])
     @players_with_tasks = section_players_with_tasks

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class EventsController < ApplicationController
-  before_action :verify_user_member_of_section
-
   def index
     start_date = params[:start_date].present? ? Date.parse(params[:start_date]) : Time.zone.today
     end_date = start_date + 1.month

--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ParticipationsController < ApplicationController
-  before_action :verify_user_member_of_section
-
   def update
     participation = Participation.find(params.expect(:id))
 

--- a/app/controllers/player_stats_controller.rb
+++ b/app/controllers/player_stats_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class PlayerStatsController < ApplicationController
-  before_action :verify_user_member_of_section
-
   SORTABLE_COLUMNS = %w[
     first_name matches_played total_goals total_seven_meters total_shots
     total_saves total_warnings total_two_minutes total_disqualifications goal_percentage

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  before_action :verify_user_member_of_section
   before_action :find_user_by_id, except: :index
   skip_before_action :verify_authenticity_token, only: %i[training_presences match_availabilities]
 

--- a/spec/controllers/concerns/prefetch_match_data_spec.rb
+++ b/spec/controllers/concerns/prefetch_match_data_spec.rb
@@ -177,6 +177,7 @@ RSpec.describe PrefetchMatchData do
   describe '#precompute_match_availability_counts' do
     it 'handles empty section gracefully' do
       empty_section = create(:section, club:)
+      empty_section.add_player!(user)
       get :index, params: { section_id: empty_section.id }
       expect(assigns(:match_availability_counts)).to be_a(Hash)
     end

--- a/spec/models/player_match_stat_spec.rb
+++ b/spec/models/player_match_stat_spec.rb
@@ -18,10 +18,14 @@ RSpec.describe PlayerMatchStat do
     let(:club) { create(:club) }
     let(:team1) { create(:team, club: club) }
     let(:team2) { create(:team, club: club) }
-    let(:day) { create(:day, calendar: calendar) }
-    let(:other_day) { create(:day, calendar: other_calendar) }
-    let(:match) { create(:match, championship: championship, local_team: team1, visitor_team: team2, day: day, start_datetime: 1.week.ago) }
-    let(:other_match) { create(:match, championship: other_championship, local_team: team1, visitor_team: team2, day: other_day, start_datetime: 1.year.ago) }
+    let(:match) do
+      create(:match, championship: championship, local_team: team1, visitor_team: team2,
+                     day: create(:day, calendar: calendar), start_datetime: 1.week.ago)
+    end
+    let(:other_match) do
+      create(:match, championship: other_championship, local_team: team1, visitor_team: team2,
+                     day: create(:day, calendar: other_calendar), start_datetime: 1.year.ago)
+    end
     let!(:stat) { create(:player_match_stat, match: match) }
     let!(:other_stat) { create(:player_match_stat, match: other_match) }
 

--- a/spec/requests/championships_spec.rb
+++ b/spec/requests/championships_spec.rb
@@ -13,6 +13,8 @@ describe 'Championships' do
 
     before { sign_in user, scope: :user }
 
+    it_behaves_like 'an endpoint denied to non-members of the section'
+
     describe 'response' do
       before { do_request }
 
@@ -26,6 +28,8 @@ describe 'Championships' do
     let(:do_request) { post section_championships_path(section), params: params }
 
     before { sign_in user, scope: :user }
+
+    it_behaves_like 'an endpoint denied to non-members of the section'
 
     it { expect { do_request }.to(change(Championship, :count)) }
 
@@ -41,6 +45,8 @@ describe 'Championships' do
     let(:do_request) { get edit_section_championship_path(section, championship) }
 
     before { sign_in user, scope: :user }
+
+    it_behaves_like 'an endpoint denied to non-members of the section'
 
     describe 'response' do
       before { do_request }

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe 'Groups' do
       post section_group_add_users_path(section, group), params: { user_id: user.id }
     end
 
+    it_behaves_like 'an endpoint denied to non-members of the section'
+
     it 'adds a user to the group' do
       expect { do_request }.to change { group.reload.users.count }.by(1)
     end

--- a/spec/requests/matches_spec.rb
+++ b/spec/requests/matches_spec.rb
@@ -12,9 +12,13 @@ describe 'Matches' do
   describe 'GET new' do
     let(:do_request) { get new_section_championship_match_path(section, championship) }
 
-    before { do_request }
+    it_behaves_like 'an endpoint denied to non-members of the section'
 
-    it { expect(response).to have_http_status(:success) }
+    describe 'response' do
+      before { do_request }
+
+      it { expect(response).to have_http_status(:success) }
+    end
   end
 
   describe 'POST selection' do
@@ -37,6 +41,8 @@ describe 'Matches' do
 
     context 'with json' do
       let(:format) { :json }
+
+      it_behaves_like 'an endpoint denied to non-members of the section'
 
       it { expect { do_request }.to change(Selection, :count).by(1) }
     end

--- a/spec/requests/section_membership_gate_spec.rb
+++ b/spec/requests/section_membership_gate_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Section membership gate' do
+  let(:section) { create(:section) }
+
+  describe 'GET section' do
+    let(:do_request) { get section_path(section) }
+
+    it_behaves_like 'an endpoint denied to non-members of the section'
+
+    context 'when signed in as a member of the section' do
+      let(:member) { create(:user, with_section: section) }
+
+      before do
+        sign_in member, scope: :user
+        do_request
+      end
+
+      it { expect(response).to have_http_status(:success) }
+    end
+
+    context 'when signed in as an admin of the club' do
+      let(:club_admin) { create(:user) }
+
+      before do
+        create(:club_admin_role, user: club_admin, club: section.club)
+        sign_in club_admin, scope: :user
+        do_request
+      end
+
+      it { expect(response).to have_http_status(:success) }
+    end
+  end
+
+  describe 'a nested section resource' do
+    let(:do_request) { get section_trainings_path(section) }
+
+    it_behaves_like 'an endpoint denied to non-members of the section'
+  end
+
+  describe 'a nested write endpoint' do
+    let(:championship) { create(:championship) }
+    let(:do_request) do
+      patch section_championship_path(section, championship), params: { championship: { name: 'hacked' } }
+    end
+
+    it_behaves_like 'an endpoint denied to non-members of the section'
+
+    it 'does not modify the record' do
+      sign_in create(:user, with_section: create(:section)), scope: :user
+      expect { do_request }.not_to(change { championship.reload.name })
+    end
+  end
+end

--- a/spec/requests/sections_spec.rb
+++ b/spec/requests/sections_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe 'Sections' do
 
   describe 'GET /sections/:id' do
     before do
+      section.add_player!(user)
       sign_in user, scope: :user
       get section_path(section)
     end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -108,6 +108,8 @@ describe 'Users' do
 
       let(:do_request) { delete section_user_path(section_id: section.to_param, id: user.to_param) }
 
+      it_behaves_like 'an endpoint denied to non-members of the section'
+
       it { expect { do_request }.to change { section.users.count }.by(-1) }
 
       describe 'response' do

--- a/spec/support/shared_examples/section_membership.rb
+++ b/spec/support/shared_examples/section_membership.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Usage: define a `do_request` let and a `section` let in the including context.
+#
+#   describe 'GET index' do
+#     let(:do_request) { get section_trainings_path(section) }
+#
+#     it_behaves_like 'an endpoint denied to non-members of the section'
+#   end
+RSpec.shared_examples 'an endpoint denied to non-members of the section' do
+  context 'when signed in as a member of another section' do
+    let(:other_section) { create(:section) }
+    let(:non_member) { create(:user, with_section: other_section) }
+
+    before do
+      sign_in non_member, scope: :user
+      do_request
+    end
+
+    it { expect(response).to have_http_status(:forbidden) }
+  end
+end


### PR DESCRIPTION
## Context

Authorization was ad hoc: `verify_user_member_of_section` ran in only 5 controllers, so any signed-in user from any club could access and modify other clubs' data through section-nested routes (championships, matches, groups, members, channels, ...).

## Changes

- `verify_user_member_of_section` is now a default `before_action` in `ApplicationController`:
  - no-ops when the route has no section (devise, visitors, users without section context, ...)
  - allows section members (player/coach), club admins (`admin_of?`), and the super admin
  - renders 403 for everyone else
- Removed the now-redundant per-controller `before_action` declarations
- New shared example `'an endpoint denied to non-members of the section'`, applied to a dedicated gate spec and to the championships/groups/matches/users request specs
- Fixed pre-existing `RSpec/MultipleMemoizedHelpers` offenses in `player_match_stat_spec.rb` that blocked the pre-push RuboCop hook

## Follow-ups (separate PRs)

This closes the cross-club hole for membership, but unscoped `Model.find(params[:id])` calls remain (a member of section A could still target section B's record ids while requesting under section A). Next PRs will scope finders through `current_section`, per controller family.

## Test

- `bin/rspec` — 619 examples, 0 failures
- `bin/rubocop` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)