### PR TITLE
Scope Championship/Match finders through current_section (IDOR fix, p…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -125,6 +125,13 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # Raises 404 (via catch404) when a record loaded by id does not belong to
+  # current_section, even though the user is a member of current_section.
+  # Callers pass whether the record is `in_section` (nil-safe via `&.`).
+  def verify_section_ownership!(in_section)
+    raise ActiveRecord::RecordNotFound if current_section.present? && !in_section
+  end
+
   private
 
   def set_sentry_context

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -127,9 +127,11 @@ class ApplicationController < ActionController::Base
 
   # Raises 404 (via catch404) when a record loaded by id does not belong to
   # current_section, even though the user is a member of current_section.
-  # Callers pass whether the record is `in_section` (nil-safe via `&.`).
-  def verify_section_ownership!(in_section)
-    raise ActiveRecord::RecordNotFound if current_section.present? && !in_section
+  def verify_section_ownership!(association, id:)
+    return if current_section.blank?
+    return if current_section.public_send(association).exists?(id)
+
+    raise ActiveRecord::RecordNotFound
   end
 
   private

--- a/app/controllers/championships_controller.rb
+++ b/app/controllers/championships_controller.rb
@@ -161,6 +161,7 @@ class ChampionshipsController < ApplicationController # rubocop:disable Metrics/
 
   def find_championship_by_id
     @championship = Championship.find params.expect(:id)
+    verify_section_ownership!(current_section&.championships&.exists?(@championship.id))
   rescue ActiveRecord::RecordNotFound
     catch404
   end

--- a/app/controllers/championships_controller.rb
+++ b/app/controllers/championships_controller.rb
@@ -161,7 +161,7 @@ class ChampionshipsController < ApplicationController # rubocop:disable Metrics/
 
   def find_championship_by_id
     @championship = Championship.find params.expect(:id)
-    verify_section_ownership!(current_section&.championships&.exists?(@championship.id))
+    verify_section_ownership!(:championships, id: @championship.id)
   rescue ActiveRecord::RecordNotFound
     catch404
   end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -3,6 +3,9 @@
 class MatchesController < ApplicationController
   include PrefetchMatchData
 
+  before_action :find_championship_for_match, only: %i[edit create update]
+  before_action :find_match_by_id, only: %i[show edit update destroy selection invitations]
+
   def index
     @section = Section.find params.expect(:section_id)
     @next_matches = @section.next_matches(end_date: 1.year.from_now).includes(
@@ -20,7 +23,6 @@ class MatchesController < ApplicationController
   end
 
   def show
-    @match = Match.find params.expect(:id)
     day = @match.day
     return if day.blank?
 
@@ -40,14 +42,10 @@ class MatchesController < ApplicationController
     @championship.enroll_team! Team.find_by(id: params[:adversary_team_id])
   end
 
-  def edit
-    @championship = Championship.find(params.expect(:championship_id))
-    @match = Match.find params.expect(:id)
-  end
+  def edit; end
 
   def create
-    @championship = Championship.find(params.expect(match: [:championship_id])[:championship_id])
-    @match = Match.new match_params
+    @match = @championship.matches.new(match_params.except(:championship_id))
     if @match.save
       redirect_to section_championship_path(current_section, @championship), notice: 'Match créé'
     else
@@ -56,9 +54,7 @@ class MatchesController < ApplicationController
   end
 
   def update
-    @championship = Championship.find(params.expect(:championship_id))
-    @match = Match.find params.expect(:id)
-    if @match.update match_params
+    if @match.update(match_params.except(:championship_id))
       redirect_to section_championship_path(current_section, @championship)
     else
       render :edit, status: :unprocessable_content
@@ -68,7 +64,6 @@ class MatchesController < ApplicationController
   def selection
     @user = User.find(params.expect(:user_id))
     team = Team.find(params.expect(:team_id))
-    @match = Match.find(params.expect(:id))
 
     @selection = Selection.create! user: @user, team:, match: @match
 
@@ -99,14 +94,11 @@ class MatchesController < ApplicationController
   end
 
   def destroy
-    @match = Match.find params.expect(:id)
     @match.destroy!
     redirect_with(fallback: root_path)
   end
 
   def invitations
-    @match = Match.find params.expect(:id)
-
     MatchInvitation.create!(match: @match, user: current_user)
     redirect_to section_path(current_section), notice: 'Relance envoyée !'
   end
@@ -121,5 +113,20 @@ class MatchesController < ApplicationController
     else
       {}
     end
+  end
+
+  def find_championship_for_match
+    championship_id = params[:championship_id] || params.expect(match: [:championship_id])[:championship_id]
+    @championship = Championship.find(championship_id)
+    verify_section_ownership!(current_section&.championships&.exists?(@championship.id))
+  rescue ActiveRecord::RecordNotFound
+    catch404
+  end
+
+  def find_match_by_id
+    @match = Match.find params.expect(:id)
+    verify_section_ownership!(current_section&.championships&.exists?(@match.championship_id))
+  rescue ActiveRecord::RecordNotFound
+    catch404
   end
 end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -118,14 +118,14 @@ class MatchesController < ApplicationController
   def find_championship_for_match
     championship_id = params[:championship_id] || params.expect(match: [:championship_id])[:championship_id]
     @championship = Championship.find(championship_id)
-    verify_section_ownership!(current_section&.championships&.exists?(@championship.id))
+    verify_section_ownership!(:championships, id: @championship.id)
   rescue ActiveRecord::RecordNotFound
     catch404
   end
 
   def find_match_by_id
     @match = Match.find params.expect(:id)
-    verify_section_ownership!(current_section&.championships&.exists?(@match.championship_id))
+    verify_section_ownership!(:championships, id: @match.championship_id)
   rescue ActiveRecord::RecordNotFound
     catch404
   end

--- a/docs/code_quality_todo.md
+++ b/docs/code_quality_todo.md
@@ -1,0 +1,191 @@
+# Code Quality TODO
+
+Audit date: 2026-07-03. Each task is self-contained so it can be delegated to another dev.
+
+Statuses: `todo` | `in_progress` | `done` | `wont_do`
+
+---
+
+## P1 — Authorization gap: any signed-in user can modify other clubs' data (IDOR)
+
+- **Status**: in_progress — strategy chosen: scoped finders (not Pundit), delivered as separate PRs per controller family. PR 1 (global `verify_user_member_of_section` gate + shared request-spec example): branch `security/section-membership-gate` — merged. PR 2 (scope `Championship`/`Match` finders through `current_section`, added `ApplicationController#verify_section_ownership!` helper, hardened `MatchesController#create`/`#update` against `championship_id` body-param spoofing): branch `security/scope-championship-match-finders`. Remaining: selection/day/training family, users/absences/participations/messages family, un-nested routes cleanup, then remove Pundit gem.
+- **Priority**: 1
+
+**Details**: Pundit is in the Gemfile and included in `ApplicationController`, but there are zero policies (`app/policies/` only contains `application_policy.rb.keep`) and zero `authorize` calls. Authorization is ad hoc: only 5 controllers use `verify_user_member_of_section`. Example: `ChampionshipsController#update` / `#update_group` load the record with `Championship.find(params.expect(:id))` and never check that the current user belongs to the owning section — any signed-in user from any club can edit another club's championships. Same pattern likely in other controllers (matches, trainings, groups…).
+
+**Expected work**:
+1. Audit every controller action that loads a record by `params[:id]` and check whether membership/role is verified.
+2. Pick one strategy: adopt Pundit properly (policies + `authorize` + `verify_authorized`) OR scope all finders through `current_section` / `current_user` associations.
+3. Add request specs asserting a user from another section gets 403/404.
+
+---
+
+## P2 — Bug: `Season.current` cached forever per Puma thread
+
+- **Status**: todo
+- **Priority**: 2
+
+**Details**: `app/models/season.rb:23` — `Thread.current[:current_season] ||= _current` is never invalidated. Puma threads live for weeks, so when the season rolls over (July 31), production keeps serving the old season until a restart. `Season.current` is used in 40+ places, including scopes and `Championship#after_initialize`.
+
+**Expected work**: Replace the thread-local memoization with one of: `Current.season` (reset per request), `Rails.cache.fetch('season/current', expires_in: 1.hour)`, or a cache keyed by `Date.current`. Add a spec proving a rollover is picked up without restart.
+
+---
+
+## P3 — Bug: `User#last_time_duty` always returns nil
+
+- **Status**: todo
+- **Priority**: 3
+
+**Details**: `app/models/user.rb:155` — `duty_tasks.where(name: task_key).order(name: :desc)`. Tasks are created with `key: task_key` (`realised_task!`); the `name` column holds the French label (see `DutyTask::TASKS`), so the `where` never matches. Ordering by `name: :desc` is also wrong — should be `realised_at: :desc`. If this feeds duty-rotation fairness, it silently returns nil for everyone.
+
+**Expected work**: Change to `duty_tasks.where(key: task_key).order(realised_at: :desc).first&.realised_at`. Add a unit spec. Check callers to see whether the broken behavior was compensated elsewhere. Also simplify `realised_task!` (`duty_tasks << DutyTask.create!(...)` — the `<<` is redundant since `create!` already sets `user`).
+
+---
+
+## P4 — Bug: `Match#selections(team)` shadows the `has_many :selections` association
+
+- **Status**: todo
+- **Priority**: 4
+
+**Details**: `app/models/match.rb:111` defines `def selections(team)` while the model also declares `has_many :selections`. Any call to `match.selections` without an argument raises `ArgumentError`.
+
+**Expected work**: Rename the method to `selections_for(team)`, update callers (views/controllers), add a spec that `match.selections` returns the association.
+
+---
+
+## P5 — Bug: `Match.of_next_7_days` returns the current week, not the next 7 days
+
+- **Status**: todo
+- **Priority**: 5
+
+**Details**: `app/models/match.rb:101` — computes `date.at_beginning_of_week..end_of_week`, i.e. the *calendar week of `date`*, not `date..date + 7.days`. Called from availability-mail logic; a Sunday run would miss next weekend's matches.
+
+**Expected work**: Decide intended semantics with product owner (calendar week vs rolling 7 days), then fix either the name or the implementation, plus specs with Timecop around week boundaries.
+
+---
+
+## P6 — Security: token auth via URL query params leaks tokens into logs
+
+- **Status**: todo
+- **Priority**: 6
+
+**Details**: `app/controllers/application_controller.rb:130` — `authenticate_user_from_token!` signs users in from `?user_email=...&user_token=...`. Tokens end up in server logs (our own `request_string` logs the full query string), browser history, and Referer headers. Tokens never expire and never rotate.
+
+**Expected work**: Replace with signed expiring tokens (`Rails.application.message_verifier` or Rails 8 `generates_token_for`) for email links; filter `user_token` from logs in the meantime (`config.filter_parameters`).
+
+---
+
+## P7 — Security: replace the two `permit!` calls (Brakeman warnings)
+
+- **Status**: todo
+- **Priority**: 7
+
+**Details**: Brakeman flags Mass Assignment at `app/controllers/sections_controller.rb:50` and `app/controllers/championships_controller.rb:79` (`params.require(:team_links).permit!`). `permit!` allows arbitrary keys.
+
+**Expected work**: Permit explicit keys/shapes for `team_links` (hash of ffhb_team_id → team_id) and the sections case. Brakeman should then report 0 warnings; add Brakeman to CI if not already there.
+
+---
+
+## P8 — N+1: `PrefetchMatchData#build_availability_counts_hash` queries inside a loop
+
+- **Status**: todo
+- **Priority**: 8
+
+**Details**: `app/controllers/concerns/prefetch_match_data.rb:74` — for each match it runs `match.match_availabilities.where(available: true).pluck(:user_id)` and `match.aways.where(...).count` (which itself joins users/participations/absences). On a section dashboard with 20 upcooming matches that's ~40 extra queries, defeating the purpose of the "prefetch" concern.
+
+**Expected work**: Compute available user ids per match from a single grouped query (data is already mostly fetched in `precompute_match_availability_counts`), and compute aways from the already-fetched absences. Assert query count in a spec (or add `bullet`/`rspec-sqlimit`).
+
+---
+
+## P9 — Refactor: extract FFHB sync/import into service objects
+
+- **Status**: todo
+- **Priority**: 9
+
+**Details**: The FFHB integration is the complexity hotspot hidden by `.rubocop_todo.yml` (AbcSize max 64 vs default 17):
+- `Championship#sync_new_matches!` (~70 lines, app/models/championship.rb:182)
+- `Match#ffhb_sync!` (app/models/match.rb:119)
+- `ChampionshipsController#new` — 35-line cascade of `return if` building FFHB form options
+- `ChampionshipsController#create` — two unrelated creation flows (FFHB import vs manual) in one nested if/else, with duplicated redirect blocks
+
+**Expected work**: Create `app/services/ffhb/` service objects (e.g. `Ffhb::ChampionshipSync`, `Ffhb::MatchSync`, `Ffhb::ImportForm`). Split FFHB import into its own controller/action to remove the branching. Lower the Metrics ceilings in `.rubocop_todo.yml` afterwards so the debt can't regrow.
+
+---
+
+## P10 — Refactor: unify availability/absence counting logic (3 divergent copies)
+
+- **Status**: todo
+- **Priority**: 10
+
+**Details**: The "who is available / away for a match" logic exists three times with subtle differences that can disagree:
+- `Match#availables` / `#aways` / `#not_availables` (app/models/match.rb:52-92)
+- `PrefetchMatchData` concern (app/controllers/concerns/prefetch_match_data.rb)
+- `User#absent_for?` / `#next_7_days_matches` (app/models/user.rb:199, 133)
+
+E.g. boundary handling of `day.period_start_date`/`period_end_date` differs between copies.
+
+**Expected work**: Extract a single query/counter object (e.g. `MatchAvailabilitySummary`) used by all three call sites, with specs covering the boundary cases (absence overlapping match start only, end only, whole period).
+
+---
+
+## P11 — Refactor: slim down the `User` god object
+
+- **Status**: todo
+- **Priority**: 11
+
+**Details**: `app/models/user.rb` (226 lines) mixes training presence, match availability, absences, duty tasks, channel read-tracking. Also: leading-underscore methods called publicly (`_set_presence_for!`, `_confirm_presence!`), `User#read?` is a predicate with a write side effect (`find_or_create_by` on read — breaks on read replicas), and `super_admin?` is hardcoded `id == 1` (fragile; one re-seed away from privilege escalation).
+
+**Expected work**:
+1. Extract concerns (`User::Attendance`, `User::Availability`) or move logic to owning models.
+2. Make underscore methods private behind proper public APIs.
+3. Make `read?` read-only; create the row in `read!` only.
+4. Replace `id == 1` with a `super_admin` boolean column or role.
+
+---
+
+## P12 — Convention: migrate remaining HAML views to Slim
+
+- **Status**: todo
+- **Priority**: 12
+
+**Details**: 47 HAML files remain vs 75 Slim (plus 16 ERB). Project convention (CLAUDE.md) is Slim with `div class="..."` for Tailwind. Mixing three template engines adds friction.
+
+**Expected work**: Migrate opportunistically when touching a view, or batch-convert low-risk views (index/show pages) with visual check. Remove `haml-rails` from the Gemfile once done.
+
+---
+
+## P13 — Tooling: add bullet, rubocop-performance, strong_migrations
+
+- **Status**: todo
+- **Priority**: 13
+
+**Details**: Three cheap guardrails missing from the Gemfile:
+- `bullet` (dev/test) — catches N+1s automatically; this codebase's main perf risk.
+- `rubocop-performance` — every other rubocop plugin is already enabled.
+- `strong_migrations` — PostgreSQL app with live data; prevents blocking migrations.
+
+**Expected work**: Add gems, configure (bullet raise in test), fix whatever they surface, wire into CI.
+
+---
+
+## P14 — Repo hygiene: remove personal/data files from the repository
+
+- **Status**: todo
+- **Priority**: 14
+
+**Details**: Repo root contains `latest.dump` (a DB dump — may hold real member PII; check git history), `homeexchange_islande_2026.csv`, `vacances_islande_2026.md`, `story_map.xmind`, `CI-DEBUG-README.md`.
+
+**Expected work**: Delete/relocate the files, add patterns to `.gitignore` (`*.dump`). If `latest.dump` with real data was ever committed, consider history rewrite (`git filter-repo`) and rotating any secrets it contains.
+
+---
+
+## P15 — Cleanup: small conventions fixes
+
+- **Status**: todo
+- **Priority**: 15
+
+**Details**: Low-risk one-liners, can be a single PR:
+- `ApplicationController` line 4: remove `extend ActiveSupport::Concern` (meant for modules, meaningless on a class).
+- `Match#meeting_datetime`: `start_datetime&.send(:-, 1.hour)` → `start_datetime && start_datetime - 1.hour`.
+- `ChampionshipsController#create`: dedupe the two identical `redirect_with` blocks.
+- `User#present_for!` / `not_present_for!` / `not_available_for!`: extract the shared "normalize arg to array" helper (`Array.wrap`).

--- a/spec/features/selections/hide_selections_spec.rb
+++ b/spec/features/selections/hide_selections_spec.rb
@@ -4,8 +4,9 @@ describe 'Hide selections', :devise do
   let(:section) { create(:section) }
   let(:coach) { create(:user, with_section_as_coach: section) }
   let(:player) { create(:user, with_section: section) }
-  let(:team) { create(:team, with_section: section) }
-  let(:match) { create(:match, local_team: team) }
+  let(:championship) { create(:championship) }
+  let(:team) { create(:team, with_section: section, enrolled_in: championship) }
+  let(:match) { create(:match, championship:, local_team: team) }
   let(:day) { match.day }
 
   describe 'Coach hide selection for players' do

--- a/spec/requests/championships_spec.rb
+++ b/spec/requests/championships_spec.rb
@@ -42,9 +42,13 @@ describe 'Championships' do
 
   describe 'GET edit' do
     let(:championship) { create(:championship) }
+    let(:championship_in_section) { true }
     let(:do_request) { get edit_section_championship_path(section, championship) }
 
-    before { sign_in user, scope: :user }
+    before do
+      create(:team, with_section: section, enrolled_in: championship) if championship_in_section
+      sign_in user, scope: :user
+    end
 
     it_behaves_like 'an endpoint denied to non-members of the section'
 
@@ -53,12 +57,25 @@ describe 'Championships' do
 
       it { expect(response).to have_http_status(:success) }
     end
+
+    context 'when the championship does not belong to the section' do
+      let(:championship_in_section) { false }
+
+      before { do_request }
+
+      it { expect(response).to have_http_status(:not_found) }
+    end
   end
 
   describe 'POST update' do
-    let!(:championship) { create(:championship) }
+    let(:championship) { create(:championship) }
+    let(:championship_in_section) { true }
     let(:new_championship_params) { { name: Faker::Company.name } }
     let(:params) { { championship: new_championship_params } }
+
+    before do
+      create(:team, with_section: section, enrolled_in: championship) if championship_in_section
+    end
 
     describe 'response' do
       before do
@@ -68,6 +85,18 @@ describe 'Championships' do
 
       it { expect(response).to redirect_to(section_championship_path(section, championship)) }
       it { expect(championship.reload.name).to eq(new_championship_params[:name]) }
+    end
+
+    context 'when the championship belongs to another section' do
+      let(:championship_in_section) { false }
+
+      before do
+        sign_in user, scope: :user
+        patch section_championship_path(section, championship), params: params
+      end
+
+      it { expect(response).to have_http_status(:not_found) }
+      it { expect(championship.reload.name).not_to eq(new_championship_params[:name]) }
     end
   end
 end

--- a/spec/requests/matches_spec.rb
+++ b/spec/requests/matches_spec.rb
@@ -9,6 +9,63 @@ describe 'Matches' do
 
   before { sign_in user, scope: :user }
 
+  describe 'ownership scoping' do
+    before { create(:team, with_section: section, enrolled_in: championship) }
+
+    let(:match) { create(:match, championship:) }
+    let(:other_championship) { create(:championship) }
+    let(:other_match) { create(:match, championship: other_championship) }
+
+    describe 'GET show' do
+      it 'succeeds for a match belonging to the current section' do
+        get section_match_path(section, match)
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns not_found for a match belonging to another section' do
+        get section_match_path(section, other_match)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    describe 'GET edit' do
+      it 'succeeds for a match belonging to the current section' do
+        get edit_section_championship_match_path(section, championship, match)
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns not_found for a match whose championship belongs to another section' do
+        get edit_section_championship_match_path(section, other_championship, other_match)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    describe 'PATCH update' do
+      let(:params) { { match: { meeting_location: 'New location' } } }
+
+      it 'updates a match belonging to the current section' do
+        patch section_championship_match_path(section, championship, match), params: params
+        expect(match.reload.meeting_location).to eq('New location')
+      end
+
+      it 'returns not_found for a match whose championship belongs to another section' do
+        patch section_championship_match_path(section, other_championship, other_match), params: params
+        expect(response).to have_http_status(:not_found)
+        expect(other_match.reload.meeting_location).not_to eq('New location')
+      end
+    end
+
+    describe 'DELETE destroy' do
+      it 'returns not_found for a match belonging to another section' do
+        other_match
+        expect do
+          delete section_match_path(section, other_match)
+        end.not_to change(Match, :count)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe 'GET new' do
     let(:do_request) { get new_section_championship_match_path(section, championship) }
 
@@ -22,9 +79,11 @@ describe 'Matches' do
   end
 
   describe 'POST selection' do
+    before { create(:team, with_section: section, enrolled_in: championship) }
+
     let(:local_team) { create(:team) }
     let(:visitor_team) { create(:team) }
-    let(:match) { create(:match, visitor_team:, local_team:) }
+    let(:match) { create(:match, championship:, visitor_team:, local_team:) }
     let(:params) { { user_id: user.id, team_id: local_team.id } }
 
     let(:do_request) { post selection_section_match_path(section, match, format: format), params: params }


### PR DESCRIPTION
…art 2)

The global membership gate from part 1 only verified the user belongs to current_section; it did not verify that a record loaded by params[:id] (championship, match) actually belongs to that section, so a member of one section could still edit/delete another club's championships and matches by guessing the id.

Adds ApplicationController#verify_section_ownership! and uses it in ChampionshipsController#find_championship_by_id and the new MatchesController before_actions. Also stops trusting the championship_id inside match form params for create/update (previously could re-parent a match to any championship regardless of the URL-scoped one).