### PR TITLE
Fix P2: Season.current no longer sticks to a stale season per Puma th…

### DIFF
--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -20,7 +20,11 @@ class Season < ApplicationRecord
   def self.current
     return _current if Rails.env.local?
 
-    Thread.current[:current_season] ||= _current
+    Rails.cache.fetch(current_cache_key, expires_in: 1.day) { _current }
+  end
+
+  def self.current_cache_key
+    "season/current/#{Date.current}"
   end
 
   def to_s

--- a/docs/code_quality_todo.md
+++ b/docs/code_quality_todo.md
@@ -22,7 +22,7 @@ Statuses: `todo` | `in_progress` | `done` | `wont_do`
 
 ## P2 — Bug: `Season.current` cached forever per Puma thread
 
-- **Status**: todo
+- **Status**: done — replaced `Thread.current[:current_season] ||= _current` with `Rails.cache.fetch("season/current/#{Date.current}", expires_in: 1.day) { _current }`. The date-scoped key guarantees a cache miss (and thus recomputation, including the coach-renewal side effect) on the first request of a new day, with no reliance on TTL timing or process restarts; `Rails.cache` is Redis-backed in dev/production, so the fix also closes the cross-process staleness gap that `Thread.current` never addressed. `Rails.env.local?` bypass preserved unchanged. Branch: `fix/season-current-cache-staleness`.
 - **Priority**: 2
 
 **Details**: `app/models/season.rb:23` — `Thread.current[:current_season] ||= _current` is never invalidated. Puma threads live for weeks, so when the season rolls over (July 31), production keeps serving the old season until a restart. `Season.current` is used in 40+ places, including scopes and `Championship#after_initialize`.

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -39,6 +39,59 @@ RSpec.describe Season do
     end
   end
 
+  describe '.current caching behavior' do
+    around do |example|
+      original_cache = Rails.cache
+      Rails.cache = ActiveSupport::Cache::MemoryStore.new
+      example.run
+      Rails.cache = original_cache
+    end
+
+    before do
+      allow(Rails.env).to receive(:local?).and_return(false)
+      Season.destroy_all
+    end
+
+    it 'memoizes the current season for the rest of the day' do
+      Timecop.freeze(Date.new(2024, 9, 15)) do
+        create(:season, start_date: Date.new(2024, 9, 1), end_date: Date.new(2025, 8, 31))
+        first_result = Season.current
+
+        create(:season, start_date: Date.new(2025, 9, 1), end_date: Date.new(2026, 8, 31))
+
+        expect(Season.current).to eq(first_result)
+      end
+    end
+
+    it 'recomputes the current season when the day rolls over, without a process restart' do
+      Timecop.freeze(Date.new(2024, 7, 31)) do
+        create(:season, start_date: Date.new(2023, 8, 1), end_date: Date.new(2024, 7, 31))
+        Season.current
+      end
+
+      Timecop.freeze(Date.new(2024, 8, 1)) do
+        expect(Season.current.start_date).to eq(Date.new(2024, 8, 1))
+        expect(Season.current.end_date).to eq(Date.new(2025, 7, 31))
+      end
+    end
+
+    it 'triggers coach renewal on the rollover day even though the previous day was cached' do
+      section = create(:section)
+      coach = create(:user)
+
+      Timecop.freeze(Date.new(2024, 7, 31)) do
+        old_season = create(:season, start_date: Date.new(2023, 8, 1), end_date: Date.new(2024, 7, 31))
+        create(:participation, user: coach, section:, season: old_season, role: Participation::COACH)
+        Season.current
+      end
+
+      Timecop.freeze(Date.new(2024, 8, 1)) do
+        new_season = Season.current
+        expect(new_season.participations.where(role: Participation::COACH, user: coach).count).to eq(1)
+      end
+    end
+  end
+
   describe '#to_s' do
     it { expect(season.to_s).to eq "#{season.start_date.year}-#{season.end_date.year}" }
   end


### PR DESCRIPTION
…read

Thread.current[:current_season] memoized forever once a worker thread computed it, so a season rollover (July 31 -> Aug 1) was never picked up without a process restart, silently skipping coach renewal for users hitting that thread. Switched to Rails.cache keyed by Date.current so the cache is shared across processes (Redis in dev/prod) and guaranteed to miss on the first request of a new day.