### PR TITLE
Fix P3: User#last_time_duty always returned nil

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,11 +149,11 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def realised_task!(task_key, realised_at, club)
-    duty_tasks << DutyTask.create!(key: task_key, realised_at:, user: self, club:)
+    duty_tasks.create!(key: task_key, realised_at:, club:)
   end
 
   def last_time_duty(task_key)
-    duty_tasks.where(name: task_key).order(name: :desc).first&.realised_at
+    duty_tasks.where(key: task_key).order(realised_at: :desc).first&.realised_at
   end
 
   def was_present?(training, presences_by_user_and_training = nil)

--- a/docs/code_quality_todo.md
+++ b/docs/code_quality_todo.md
@@ -33,7 +33,7 @@ Statuses: `todo` | `in_progress` | `done` | `wont_do`
 
 ## P3 — Bug: `User#last_time_duty` always returns nil
 
-- **Status**: todo
+- **Status**: done — fixed the finder to `duty_tasks.where(key: task_key).order(realised_at: :desc).first&.realised_at`; `last_time_duty` had no callers in `app/`, so no compensating logic existed elsewhere. Also simplified `realised_task!` to `duty_tasks.create!(...)` (the `duty_tasks << DutyTask.create!(...)` was redundant since `create!` on the association already sets `user`). Added specs for both the never-realised (nil) and most-recent-wins cases. Branch: `fix/user-last-time-duty-nil`.
 - **Priority**: 3
 
 **Details**: `app/models/user.rb:155` — `duty_tasks.where(name: task_key).order(name: :desc)`. Tasks are created with `key: task_key` (`realised_task!`); the `name` column holds the French label (see `DutyTask::TASKS`), so the `where` never matches. Ordering by `name: :desc` is also wrong — should be `realised_at: :desc`. If this feeds duty-rotation fairness, it silently returns nil for everyone.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -368,6 +368,26 @@ describe User do
     end
   end
 
+  describe '#last_time_duty' do
+    let(:task) { DutyTask::TASKS.keys.sample }
+
+    context 'when the user never realised the task' do
+      it { expect(user.last_time_duty(task)).to be_nil }
+    end
+
+    context 'when the user realised the task multiple times' do
+      before do
+        user.realised_task!(task, 3.days.ago, section.club)
+        user.realised_task!(task, 1.day.ago, section.club)
+        user.realised_task!(task, 2.days.ago, section.club)
+      end
+
+      it 'returns the most recent realised_at' do
+        expect(user.last_time_duty(task)).to be_within(1.second).of(1.day.ago)
+      end
+    end
+  end
+
   describe 'validates presence on trainings' do
     subject(:was_present) { user.was_present?(training) }
 


### PR DESCRIPTION
duty_tasks are created with key: task_key, but last_time_duty queried where(name: task_key) — name holds the French label, not the key — so the where clause never matched. Ordering by name: :desc was also wrong; now orders by realised_at: :desc to actually return the most recent occurrence.

Also simplified realised_task! to duty_tasks.create!(...), dropping the redundant duty_tasks << since create! on the association already sets user.