### PR TITLE
Fix P4: Match#selections(team) shadows has_many :selections association

### DIFF
--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -108,7 +108,7 @@ class Match < ApplicationRecord # rubocop:disable Metrics/ClassLength
     Team.where(id: [local_team_id, visitor_team_id])
   end
 
-  def selections(team)
+  def selections_for(team)
     Selection.includes(:user).where(match: self, team:)
   end
 

--- a/app/views/matches/show.html.slim
+++ b/app/views/matches/show.html.slim
@@ -35,10 +35,10 @@ p
         ul.divide-y.divide-sky-600.rounded-md.border.border-sky-600
           li.bg-sky-600.p-1.text-white.text-center
             = link_to section_day_selections_path(current_section, @match.day), class: 'ml-2 text-white hover:underline', title: 'Voir les sélections' do
-              = "Sélection #{team.name} (#{@match.selections(team).count} joueurs)"
+              = "Sélection #{team.name} (#{@match.selections_for(team).count} joueurs)"
               svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 inline ml-2"
                 path stroke-linecap="round" stroke-linejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23-.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5"
 
-          - @match.selections(team).each do |selection|
+          - @match.selections_for(team).each do |selection|
             li.list-group-item.px-1
               = selection.user.full_name

--- a/app/views/selections/index.html.slim
+++ b/app/views/selections/index.html.slim
@@ -25,7 +25,7 @@ div class="sm:flex sm:items-center mb-5"
           hr
           .select-all
             - @teams_with_matches.each do |team, match|
-              - selections = match.selections(team).includes(:user).sort{|a, b| a.user.short_name <=> b.user.short_name}
+              - selections = match.selections_for(team).includes(:user).sort{|a, b| a.user.short_name <=> b.user.short_name}
               p.py-4
                 h3.text-xl= team.name
                 'Match :
@@ -87,7 +87,7 @@ div class="sm:flex sm:items-center mb-5"
               = render partial: 'player', object: player, locals: {teams_with_matches: @teams_with_matches, selection: nil, display_teams: true}
 
     - @teams_with_matches.each do |team, match|
-      - selections = match.selections(team).includes(:match).includes(:team).includes(user: [:match_availabilities, :user_championship_stats]).sort{|a, b| a.user.short_name <=> b.user.short_name}
+      - selections = match.selections_for(team).includes(:match).includes(:team).includes(user: [:match_availabilities, :user_championship_stats]).sort{|a, b| a.user.short_name <=> b.user.short_name}
       div
         .overflow-hidden.shadow-sm.shadow-sky-600.ring-1.ring-black.ring-opacity-5.rounded-xs data-match_id=match.id data-team_id=team.id
           .bg-sky-600.p-1.text-white.text-center

--- a/docs/code_quality_todo.md
+++ b/docs/code_quality_todo.md
@@ -44,7 +44,7 @@ Statuses: `todo` | `in_progress` | `done` | `wont_do`
 
 ## P4 — Bug: `Match#selections(team)` shadows the `has_many :selections` association
 
-- **Status**: todo
+- **Status**: done — renamed to `selections_for(team)`, updated the three callers (`app/views/matches/show.html.slim`, `app/views/selections/index.html.slim` x2). Added specs proving `match.selections` now returns the association and `match.selections_for(team)` scopes correctly. Branch: `fix/match-selections-shadow-association`.
 - **Priority**: 4
 
 **Details**: `app/models/match.rb:111` defines `def selections(team)` while the model also declares `has_many :selections`. Any call to `match.selections` without an argument raises `ArgumentError`.

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -71,6 +71,32 @@ RSpec.describe Match do
     it { is_expected.not_to be_empty }
   end
 
+  describe '#selections' do
+    subject(:selections) { match.selections }
+
+    let(:match) { create(:match) }
+
+    it 'returns the has_many association, not the team-scoped method' do
+      selection = create(:selection, match:)
+
+      expect(selections).to contain_exactly(selection)
+    end
+  end
+
+  describe '#selections_for' do
+    subject(:selections_for) { match.selections_for(team) }
+
+    let(:team) { create(:team) }
+    let(:match) { create(:match) }
+
+    it 'returns only the selections for the given team' do
+      selection = create(:selection, match:, team:)
+      create(:selection, match:)
+
+      expect(selections_for).to contain_exactly(selection)
+    end
+  end
+
   describe '#meeting_datetime' do
     subject(:datetime) { Match.new(meeting_datetime:, start_datetime:).meeting_datetime }
 


### PR DESCRIPTION
Renamed to selections_for(team) so match.selections without an argument returns the association instead of raising ArgumentError. Updated the three view callers and added specs covering both #selections and #selections_for.