### PR TITLE
Fix P6: replace permanent email-link tokens with expiring signed toke…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,13 +49,21 @@ class ApplicationController < ActionController::Base
   end
 
   def request_string
-    "--REQ--;#{Rails.env};#{current_user&.id};#{current_user&.email};#{request.method};#{request.url};#{request.host};#{request.query_string};#{filter_params(params)};"
+    "--REQ--;#{Rails.env};#{current_user&.id};#{current_user&.email};#{request.method};#{filtered_url};#{request.host};#{filtered_query_string};#{filter_params(params)};"
   end
 
   def filter_params(params)
     filters = Rails.application.config.filter_parameters
     f = ActiveSupport::ParameterFilter.new filters
     f.filter params
+  end
+
+  def filtered_query_string
+    filter_params(request.GET).to_query
+  end
+
+  def filtered_url
+    request.query_string.blank? ? request.url : "#{request.base_url}#{request.path}?#{filtered_query_string}"
   end
 
   def redirect_with(fallback: root_path, additionnal_params: {}, use_referrer: true, **options)
@@ -150,10 +158,10 @@ class ApplicationController < ActionController::Base
   end
 
   def authenticate_user_from_token!
-    user_email = params[:user_email].presence
-    user       = user_email && User.find_by(email: user_email)
+    token = params[:user_token].presence
+    user  = token && User.find_by_token_for(:email_authentication, token)
 
-    sign_in user if user && Devise.secure_compare(user.authentication_token, params[:user_token])
+    sign_in user if user
   end
 
   def set_current_user_in_current

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,10 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   before_validation :ensure_authentication_token
 
+  generates_token_for :email_authentication, expires_in: 30.days do
+    authentication_token
+  end
+
   scope :active_this_season, -> { includes(:participations).where(participations: { season: Season.current }) }
 
   def has_only_one_section?

--- a/app/views/user_mailer/send_match_invitation.html.haml
+++ b/app/views/user_mailer/send_match_invitation.html.haml
@@ -4,8 +4,7 @@
   Merci d'indiquer ta disponibilité aux matchs suivants :
 
 %form{action: match_availabilities_user_url(@user.to_param), method: :post}
-  %input{type: :hidden, name: :user_email, value: @user.email}
-  %input{type: :hidden, name: :user_token, value: @user.authentication_token}
+  %input{type: :hidden, name: :user_token, value: @user.generate_token_for(:email_authentication)}
   %table{style: 'width: 600px;border-collapse: collapse;'}
     %tr{style: 'text-align: left;'}
       %th{style: 'border: 1px grey solid;'} Horaire
@@ -26,8 +25,8 @@
     %tr
       %td{colspan: 3}
         - non_burned_matches = @matches.select{ |match| !match.burned?(@user) }
-        %a{style: "float: left; text-decoration: none; background:#5cb85c;display:inline-block;padding:10px;font-size:14px;margin:10px 10px 0 0;color:white;", href: match_availabilities_user_url(@user.to_param, present_ids: non_burned_matches.map(&:id), checked_ids: non_burned_matches.map(&:id), user_email: @user.email, user_token: @user.authentication_token), method: :post} Dispo pour tous !!
-        %a{style: "float: left; text-decoration: none; background:#d9534f;display:inline-block;padding:10px;font-size:14px;margin:10px 10px 0 10px;color:white;", href: match_availabilities_user_url(@user.to_param, present_ids: non_burned_matches.map(&:id), checked_ids: []), user_email: @user.email, user_token: @user.authentication_token, method: :post} Dispo pour aucun :(
+        %a{style: "float: left; text-decoration: none; background:#5cb85c;display:inline-block;padding:10px;font-size:14px;margin:10px 10px 0 0;color:white;", href: match_availabilities_user_url(@user.to_param, present_ids: non_burned_matches.map(&:id), checked_ids: non_burned_matches.map(&:id), user_token: @user.generate_token_for(:email_authentication)), method: :post} Dispo pour tous !!
+        %a{style: "float: left; text-decoration: none; background:#d9534f;display:inline-block;padding:10px;font-size:14px;margin:10px 10px 0 10px;color:white;", href: match_availabilities_user_url(@user.to_param, present_ids: non_burned_matches.map(&:id), checked_ids: []), user_token: @user.generate_token_for(:email_authentication), method: :post} Dispo pour aucun :(
         %button{type: :submit, style: "float: right; background:#428bca;display:inline-block;padding:10px;font-size:14px;margin:10px 0 0 10px;color:white; border: none;"} Valider mes dispos
 
 %p

--- a/app/views/user_mailer/send_training_invitation.html.haml
+++ b/app/views/user_mailer/send_training_invitation.html.haml
@@ -4,8 +4,7 @@
   Merci d'indiquer ta présence aux entrainements suivants :
 
 %form{action: training_presences_user_url(@user.to_param), method: :post}
-  %input{type: :hidden, name: :user_email, value: @user.email}
-  %input{type: :hidden, name: :user_token, value: @user.authentication_token}
+  %input{type: :hidden, name: :user_token, value: @user.generate_token_for(:email_authentication)}
   %table{style: 'width: 600px;border-collapse: collapse;'}
     %tr{style: 'text-align: left;'}
       %th{style: 'border: 1px grey solid;'} Horaire
@@ -24,8 +23,8 @@
             %input{ type: :checkbox, name: 'checked_ids[]', value: training.id, checked: @user.present_for?(training) }
     %tr
       %td{colspan: 3}
-        %a{style: "float: left; text-decoration: none; background:#5cb85c;display:inline-block;padding:10px;font-size:14px;margin:10px 10px 0 0;color:white;", href: training_presences_user_url(@user.to_param, present_ids: @trainings.map(&:id), checked_ids: @trainings.map(&:id), user_email: @user.email, user_token: @user.authentication_token)} Présent à tous !!
-        %a{style: "float: left; text-decoration: none; background:#d9534f;display:inline-block;padding:10px;font-size:14px;margin:10px 10px 0 10px;color:white;", href: training_presences_user_url(@user.to_param, present_ids: @trainings.map(&:id), checked_ids: []), user_email: @user.email, user_token: @user.authentication_token} Présent à aucun :(
+        %a{style: "float: left; text-decoration: none; background:#5cb85c;display:inline-block;padding:10px;font-size:14px;margin:10px 10px 0 0;color:white;", href: training_presences_user_url(@user.to_param, present_ids: @trainings.map(&:id), checked_ids: @trainings.map(&:id), user_token: @user.generate_token_for(:email_authentication))} Présent à tous !!
+        %a{style: "float: left; text-decoration: none; background:#d9534f;display:inline-block;padding:10px;font-size:14px;margin:10px 10px 0 10px;color:white;", href: training_presences_user_url(@user.to_param, present_ids: @trainings.map(&:id), checked_ids: []), user_token: @user.generate_token_for(:email_authentication)} Présent à aucun :(
         %button{type: :submit, style: "float: right; background:#428bca;display:inline-block;padding:10px;font-size:14px;margin:10px 0 0 10px;color:white; border: none;"} Valider mes présences
 
 %p

--- a/docs/code_quality_todo.md
+++ b/docs/code_quality_todo.md
@@ -66,7 +66,7 @@ Statuses: `todo` | `in_progress` | `done` | `wont_do`
 
 ## P6 — Security: token auth via URL query params leaks tokens into logs
 
-- **Status**: todo
+- **Status**: done — `User` now uses Rails 8 `generates_token_for(:email_authentication, expires_in: 30.days) { authentication_token }`, so email links carry a single signed, expiring `user_token` instead of the permanent `authentication_token` plus a plaintext `user_email`. `ApplicationController#authenticate_user_from_token!` resolves via `User.find_by_token_for`; token is invalidated automatically if `authentication_token` is ever rotated, or after 30 days. Also fixed the actual log leak: `request_string` was interpolating raw `request.url`/`request.query_string` (bypassing the `filter_parameters` masking that only applied to the separately-logged `params` hash) — added `filtered_url`/`filtered_query_string` that run the query string through the same `ActiveSupport::ParameterFilter` before logging. Updated the two invitation mailer views and the request specs that exercised token auth directly. Branch: `security/expiring-email-auth-tokens`.
 - **Priority**: 6
 
 **Details**: `app/controllers/application_controller.rb:130` — `authenticate_user_from_token!` signs users in from `?user_email=...&user_token=...`. Tokens end up in server logs (our own `request_string` logs the full query string), browser history, and Referer headers. Tokens never expire and never rotate.

--- a/spec/controllers/application_controller_log_requests_spec.rb
+++ b/spec/controllers/application_controller_log_requests_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe ApplicationController do
 
         expect { get(:index, params: { error: true }) }.to raise_error(RuntimeError, 'TEST ERROR')
       end
+
+      it 'filters sensitive query string params out of the logged request' do
+        logged_line = nil
+        allow(Rails.logger).to receive(:info) { |msg| logged_line = msg if msg =~ /REQ/ }
+
+        get :index, params: { user_token: 'super-secret-token' }
+
+        expect(logged_line).not_to include('super-secret-token')
+        expect(logged_line).to include('[FILTERED]')
+      end
     end
 
     context 'when in test env' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,6 +50,27 @@ describe User do
     its(:id) { is_expected.not_to be_nil }
   end
 
+  describe 'email_authentication token' do
+    it 'resolves back to the user' do
+      token = user.generate_token_for(:email_authentication)
+      expect(User.find_by_token_for(:email_authentication, token)).to eq(user)
+    end
+
+    it 'expires after 30 days' do
+      token = user.generate_token_for(:email_authentication)
+      Timecop.travel 31.days.from_now
+      expect(User.find_by_token_for(:email_authentication, token)).to be_nil
+      Timecop.return
+    end
+
+    it 'is invalidated when the authentication_token changes' do
+      token = user.generate_token_for(:email_authentication)
+      user.update!(authentication_token: SecureRandom.urlsafe_base64(32))
+
+      expect(User.find_by_token_for(:email_authentication, token)).to be_nil
+    end
+  end
+
   describe '#short_name' do
     it 'returns nickname or full name' do
       user = create(:user, nickname: nil)

--- a/spec/requests/clubs_spec.rb
+++ b/spec/requests/clubs_spec.rb
@@ -8,11 +8,28 @@ RSpec.describe 'Clubs' do
 
   describe 'GET /clubs/:id' do
     before do
-      get club_path(club), params: { user_email: user.email, user_token: user.authentication_token }
+      get club_path(club), params: { user_token: user.generate_token_for(:email_authentication) }
     end
 
     it { expect(response).to have_http_status(:success) }
     # NOTE: We can't test assigns in request specs, but we can test that the response contains expected content
     # if needed for more thorough testing
+  end
+
+  describe 'GET /clubs/:id with an invalid or expired token' do
+    it 'does not sign in with a garbage token' do
+      get club_path(club), params: { user_token: 'not-a-real-token' }
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it 'does not sign in with an expired token' do
+      token = user.generate_token_for(:email_authentication)
+      Timecop.travel 31.days.from_now
+      get club_path(club), params: { user_token: token }
+      Timecop.return
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
   end
 end

--- a/spec/requests/sections_spec.rb
+++ b/spec/requests/sections_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Sections' do
     context 'when user is authenticated' do
       before do
         club.add_admin!(user)
-        get new_club_section_path(club), params: { user_email: user.email, user_token: user.authentication_token }
+        get new_club_section_path(club), params: { user_token: user.generate_token_for(:email_authentication) }
       end
 
       it { expect(response).to have_http_status(:success) }
@@ -39,7 +39,7 @@ RSpec.describe 'Sections' do
 
       before do
         get new_club_section_path(club),
-            params: { user_email: another_user.email, user_token: another_user.authentication_token }
+            params: { user_token: another_user.generate_token_for(:email_authentication) }
       end
 
       it { expect(response).to have_http_status(:redirect) }
@@ -49,7 +49,7 @@ RSpec.describe 'Sections' do
   describe 'POST /clubs/:club_id/sections' do
     let(:section_attributes) { attributes_for(:section, club: nil) }
     let(:auth_params) do
-      { user_email: user.email, user_token: user.authentication_token }
+      { user_token: user.generate_token_for(:email_authentication) }
     end
 
     before do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -116,7 +116,7 @@ describe 'Users' do
 
     let(:post_training_presences) do
       post training_presences_user_path(id: user.to_param), params: {
-        user_email: user.email, user_token: user.authentication_token,
+        user_token: user.generate_token_for(:email_authentication),
         present_ids: [training1.id, training2.id, training_full.id], checked_ids: [training1.id, training_full.id]
       }
     end
@@ -136,7 +136,7 @@ describe 'Users' do
 
       let(:post_training_presences) do
         post training_presences_user_path(id: user.to_param), params: {
-          user_email: user.email, user_token: user.authentication_token,
+          user_token: user.generate_token_for(:email_authentication),
           present_ids: [other_training.id], checked_ids: [other_training.id]
         }
       end
@@ -152,7 +152,7 @@ describe 'Users' do
     let(:match) { create(:match, championship:) }
     let(:post_match_availabilities) do
       post match_availabilities_user_path(id: user.to_param), params: {
-        user_email: user.email, user_token: user.authentication_token,
+        user_token: user.generate_token_for(:email_authentication),
         present_ids: [match.id], checked_ids: [match.id]
       }
     end
@@ -170,7 +170,7 @@ describe 'Users' do
 
       let(:post_match_availabilities) do
         post match_availabilities_user_path(id: user.to_param), params: {
-          user_email: user.email, user_token: user.authentication_token,
+          user_token: user.generate_token_for(:email_authentication),
           present_ids: [other_match.id], checked_ids: [other_match.id]
         }
       end


### PR DESCRIPTION
…ns; stop logging raw query strings

authenticate_user_from_token! compared params[:user_token] against the permanent authentication_token column, with user_email identifying the account in plaintext — both sent over email links that never expire or rotate. Switched to Rails 8 generates_token_for(:email_authentication, expires_in: 30.days), so links carry a single signed token that expires and is invalidated if authentication_token is ever rotated.

Also fixed the actual log leak: request_string interpolated raw request.url/request.query_string, bypassing the filter_parameters masking that only applied to the separately-logged params hash. Added filtered_url/filtered_query_string that run the query string through the same ActiveSupport::ParameterFilter before logging.