### PR TITLE
Fix P7: tighten dynamic-hash strong params behind old permit! warnings

### DIFF
--- a/app/controllers/championships_controller.rb
+++ b/app/controllers/championships_controller.rb
@@ -76,7 +76,7 @@ class ChampionshipsController < ApplicationController # rubocop:disable Metrics/
         redirect_to new_section_championship_path(current_section, params: params.permit(all_params))
       else
         permitted_params = params.permit(all_params).to_h.except(:ffhb).symbolize_keys
-        permitted_params[:team_links] = params.expect(team_links: {}).to_h
+        permitted_params[:team_links] = team_links_params
         if params[:championship] && params[:championship][:calendar].present?
           linked_calendar = Calendar.find(params.expect(championship: [:calendar])[:calendar])
         end
@@ -157,6 +157,15 @@ class ChampionshipsController < ApplicationController # rubocop:disable Metrics/
     else
       {}
     end
+  end
+
+  # team_links maps FFHB team ids (dynamic keys) to local team ids.
+  # Keys can't be enumerated, so restrict values instead: scalar strings only,
+  # and any linked team must belong to the current section.
+  def team_links_params
+    links = params.expect(team_links: {}).to_h.select { |_ffhb_team_id, team_id| team_id.is_a?(String) }
+    allowed_team_ids = current_section.teams.where(id: links.values.compact_blank).ids.map(&:to_s)
+    links.select { |_ffhb_team_id, team_id| team_id.blank? || allowed_team_ids.include?(team_id) }
   end
 
   def find_championship_by_id

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -47,10 +47,11 @@ class SectionsController < ApplicationController
   end
 
   def player_ffhb_association
-    players_params = params.expect(section: {})
+    # Keys are dynamic (player_<user_id> => ffhb player id), so restrict values to scalar strings.
+    players_params = params.expect(section: {}).to_h.select do |key, ffhb_key|
+      key.start_with?('player_') && ffhb_key.is_a?(String)
+    end
     players_params.each do |key, ffhb_key|
-      next unless key.start_with?('player_')
-
       user_id = key.split('_')[1]
       user = current_section.users.find(user_id)
       UserChampionshipStat.where(player_id: ffhb_key).update_all(user_id: user.id) # rubocop:disable Rails/SkipsModelValidations

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -22,53 +22,7 @@
         89
       ],
       "note": "Actually not user input"
-    },
-    {
-      "warning_type": "Mass Assignment",
-      "warning_code": 70,
-      "fingerprint": "0a2c7caae528481eaf8be647957987ad1c6eada59cd160eac47dd65b04d5605b",
-      "check_name": "MassAssignment",
-      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
-      "file": "app/controllers/sections_controller.rb",
-      "line": 43,
-      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params[:section].permit!",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "SectionsController",
-        "method": "player_ffhb_association"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "cwe_id": [
-        915
-      ],
-      "note": "Accept mass assignements because it's dinamic with FFHB inputs"
-    },
-    {
-      "warning_type": "Mass Assignment",
-      "warning_code": 70,
-      "fingerprint": "249e92f6bfd743bb6c66d8043ffbf6dbdc9bd7c972ac10b800a0273d845d69fc",
-      "check_name": "MassAssignment",
-      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
-      "file": "app/controllers/championships_controller.rb",
-      "line": 64,
-      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params[:team_links].permit!",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ChampionshipsController",
-        "method": "create"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "cwe_id": [
-        915
-      ],
-      "note": ""
     }
   ],
-  "brakeman_version": "7.1.0"
+  "brakeman_version": "8.0.5"
 }

--- a/docs/code_quality_todo.md
+++ b/docs/code_quality_todo.md
@@ -77,7 +77,7 @@ Statuses: `todo` | `in_progress` | `done` | `wont_do`
 
 ## P7 — Security: replace the two `permit!` calls (Brakeman warnings)
 
-- **Status**: todo
+- **Status**: done — the raw `permit!` calls had already been replaced by `params.expect(...: {})`, which silenced Brakeman but still permitted arbitrary hash contents. Tightened both: `ChampionshipsController#create` now builds `team_links` via `team_links_params`, which keeps only scalar string values and drops any team id that doesn't belong to `current_section.teams` (previously any signed-in user could link another club's team into their championship via `Team.find`); `SectionsController#player_ffhb_association` now filters to `player_*` keys with scalar string values. Removed the two obsolete Mass Assignment entries from `config/brakeman.ignore` (only the reviewed Section SQL note remains); Brakeman reports 0 warnings and was already wired into CI (`.github/workflows/main.yml` `brakeman` job). Added request specs asserting a section team gets linked and a foreign club's team is ignored. Branch: `security/p7-tighten-dynamic-params`.
 - **Priority**: 7
 
 **Details**: Brakeman flags Mass Assignment at `app/controllers/sections_controller.rb:50` and `app/controllers/championships_controller.rb:79` (`params.require(:team_links).permit!`). `permit!` allows arbitrary keys.

--- a/spec/requests/championships_spec.rb
+++ b/spec/requests/championships_spec.rb
@@ -40,6 +40,43 @@ describe 'Championships' do
     end
   end
 
+  describe 'POST create from FFHB' do
+    let(:my_team) { create(:team, with_section: section) }
+    let(:other_team) { create(:team) }
+    let(:ffhb_params) do
+      { ffhb: '1',
+        type_competition: 'D',
+        code_comite: '94',
+        code_competition: '16-ans-m-2-eme-division-territoriale-94-75-23229',
+        phase_id: '41894',
+        code_pool: '128335' }
+    end
+    let(:do_request) { post section_championships_path(section), params: ffhb_params.merge(team_links:) }
+
+    before do
+      mock_ffhb
+      sign_in user, scope: :user
+    end
+
+    context 'when team_links reference a team of the section' do
+      let(:team_links) { { '1589702' => my_team.id.to_s } }
+
+      it 'links the team' do
+        do_request
+        expect(Championship.last.teams).to include(my_team)
+      end
+    end
+
+    context "when team_links reference another club's team" do
+      let(:team_links) { { '1589702' => other_team.id.to_s } }
+
+      it 'ignores the foreign team and creates a placeholder instead' do
+        do_request
+        expect(Championship.last.teams).not_to include(other_team)
+      end
+    end
+  end
+
   describe 'GET edit' do
     let(:championship) { create(:championship) }
     let(:championship_in_section) { true }


### PR DESCRIPTION
## Summary
- The two Brakeman `permit!` warnings (P7 in `docs/code_quality_todo.md`) had already been silenced by switching to `params.expect(...: {})`, but that still permits arbitrary hash contents.
- `ChampionshipsController#create` now builds `team_links` via a `team_links_params` helper: scalar string values only, and any linked team id must belong to `current_section.teams`. Previously any signed-in user could link **another club's team** into their championship, since `FfhbService#build_teams` resolves ids with an unscoped `Team.find`.
- `SectionsController#player_ffhb_association` now only processes `player_*` keys with scalar string values.
- Removed the two obsolete Mass Assignment entries from `config/brakeman.ignore` (only the reviewed SQL note on `Section#next_duties_for` remains). Brakeman reports 0 warnings and already runs in CI.

## Test plan
- [x] New request specs: a section team passed in `team_links` gets linked; another club's team is ignored (placeholder created instead)
- [x] `bin/rspec` — 679 examples, 0 failures
- [x] `bundle exec brakeman` — 0 warnings
- [x] `bin/rubocop -A` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)