### PR TITLE
Fix P8: remove per-match N+1 queries in PrefetchMatchData

### DIFF
--- a/app/controllers/concerns/prefetch_match_data.rb
+++ b/app/controllers/concerns/prefetch_match_data.rb
@@ -23,32 +23,28 @@ module PrefetchMatchData
     match_ids = @next_matches.map(&:id)
     section_player_ids = @section.players.pluck(:id)
 
-    availability_counts = MatchAvailability
-                          .where(match_id: match_ids, user_id: section_player_ids)
-                          .group(:match_id, :available)
-                          .count
+    availabilities_by_match = MatchAvailability
+                              .where(match_id: match_ids, user_id: section_player_ids)
+                              .pluck(:match_id, :user_id, :available)
+                              .group_by(&:first)
 
-    absences_by_match = calculate_absences_by_match(section_player_ids)
+    absences = section_player_absences(section_player_ids)
 
     @match_availability_counts = build_availability_counts_hash(
-      availability_counts,
-      absences_by_match,
+      availabilities_by_match,
+      absences,
       section_player_ids.size
     )
   end
 
-  def calculate_absences_by_match(section_player_ids)
-    absences_by_match = Hash.new(0)
-    return absences_by_match if section_player_ids.empty?
+  def section_player_absences(section_player_ids)
+    return [] if section_player_ids.empty?
 
     min_match_time = @next_matches.map { |m| m.start_datetime || m.day&.period_start_date }.compact.min
     max_match_time = @next_matches.map { |m| m.start_datetime || m.day&.period_end_date }.compact.max
-    return absences_by_match unless min_match_time && max_match_time
+    return [] if min_match_time.blank? || max_match_time.blank?
 
-    absences = fetch_absences_for_period(min_match_time, max_match_time)
-    match_absences_to_matches(absences, absences_by_match)
-
-    absences_by_match
+    fetch_absences_for_period(min_match_time, max_match_time).to_a
   end
 
   def fetch_absences_for_period(min_match_time, max_match_time)
@@ -59,43 +55,31 @@ module PrefetchMatchData
       .select('DISTINCT participations.user_id, absences.start_at, absences.end_at')
   end
 
-  def match_absences_to_matches(absences, absences_by_match)
-    @next_matches.each do |match|
-      start_time = match.start_datetime || match.day&.period_start_date
-      end_time = match.end_datetime || match.day&.period_end_date
-      next if start_time.blank? || end_time.blank?
+  def absences_covering(absences, match)
+    start_time = match.start_datetime || match.day&.period_start_date
+    end_time = match.end_datetime || match.day&.period_end_date
+    return [] if start_time.blank? || end_time.blank?
 
-      absences_by_match[match.id] = absences.count do |absence|
-        absence.start_at <= start_time && absence.end_at >= end_time
-      end
-    end
+    absences.select { |absence| absence.start_at <= start_time && absence.end_at >= end_time }
   end
 
-  def build_availability_counts_hash(availability_counts, absences_by_match, total_players)
+  def build_availability_counts_hash(availabilities_by_match, absences, total_players)
     counts_hash = {}
     @next_matches.each do |match|
-      available_count = availability_counts[[match.id, true]] || 0
-      not_available_count = availability_counts[[match.id, false]] || 0
-      away_count = absences_by_match[match.id] || 0
+      rows = availabilities_by_match[match.id] || []
+      available_user_ids = rows.filter_map { |_match_id, user_id, available| user_id if available }
+      not_available_count = rows.count { |_match_id, _user_id, available| available == false }
+
+      match_absences = absences_covering(absences, match)
 
       # Only subtract absences from available count if they were marked available
       # The away players who are already marked not_available or have no response shouldn't be double-counted
-      available_away_ids = match.match_availabilities.where(available: true).pluck(:user_id)
-
-      actual_away_from_available = if away_count.positive?
-                                     match.aways.where(id: available_away_ids).count
-                                   else
-                                     0
-                                   end
-
-      actual_available = [available_count - actual_away_from_available, 0].max
-      actual_not_available = not_available_count + away_count
-      no_response_count = total_players - available_count - not_available_count
+      away_from_available = match_absences.count { |absence| available_user_ids.include?(absence.user_id) }
 
       counts_hash[match.id] = {
-        available: actual_available,
-        not_available: actual_not_available,
-        no_response: no_response_count
+        available: [available_user_ids.size - away_from_available, 0].max,
+        not_available: not_available_count + match_absences.size,
+        no_response: total_players - available_user_ids.size - not_available_count
       }
     end
     counts_hash

--- a/docs/code_quality_todo.md
+++ b/docs/code_quality_todo.md
@@ -88,7 +88,7 @@ Statuses: `todo` | `in_progress` | `done` | `wont_do`
 
 ## P8 — N+1: `PrefetchMatchData#build_availability_counts_hash` queries inside a loop
 
-- **Status**: todo
+- **Status**: done — replaced the per-match `match.match_availabilities.where(available: true).pluck(:user_id)` and `match.aways.where(...).count` with two upfront queries: a single `pluck(:match_id, :user_id, :available)` over all matches/section players (grouped in Ruby), and the existing single absence fetch, now kept as rows and intersected per match in memory (`absences_covering` reuses the same `start_at <= start && end_at >= end` predicate the old `match.aways` used). Side effect: the "away while marked available" subtraction is now consistently scoped to section players, matching the availability counts it is subtracted from. Added a regression spec that counts `sql.active_record` SELECTs on `match_availabilities` across 10 matches (≤3 allowed; verified it fails against the old implementation). Branch: `perf/p8-prefetch-match-data-n-plus-1`.
 - **Priority**: 8
 
 **Details**: `app/controllers/concerns/prefetch_match_data.rb:74` — for each match it runs `match.match_availabilities.where(available: true).pluck(:user_id)` and `match.aways.where(...).count` (which itself joins users/participations/absences). On a section dashboard with 20 upcooming matches that's ~40 extra queries, defeating the purpose of the "prefetch" concern.

--- a/spec/controllers/concerns/prefetch_match_data_spec.rb
+++ b/spec/controllers/concerns/prefetch_match_data_spec.rb
@@ -155,6 +155,37 @@ RSpec.describe PrefetchMatchData do
     end
   end
 
+  describe 'query count' do
+    let!(:more_matches) do
+      create_list(:match, 8, championship:, local_team: team1, visitor_team: team2, day:,
+                             start_datetime: 1.week.from_now)
+    end
+
+    before do
+      section.players.find_each do |player|
+        [match1, match2, *more_matches].each do |match|
+          create(:match_availability, user: player, match:, available: true)
+        end
+      end
+      create(:absence, user: player1, start_at: 5.days.from_now, end_at: 10.days.from_now)
+    end
+
+    it 'does not run per-match queries' do
+      queries = []
+      counter = lambda do |_name, _start, _finish, _id, payload|
+        queries << payload[:sql] if payload[:sql].match?(/\A\s*SELECT/i) && payload[:name] != 'SCHEMA'
+      end
+
+      ActiveSupport::Notifications.subscribed(counter, 'sql.active_record') do
+        get :index, params: { section_id: section.id }
+      end
+
+      availability_queries = queries.grep(/match_availabilities/)
+      # one for the current user's availabilities, one grouped fetch for all section players
+      expect(availability_queries.size).to be <= 3
+    end
+  end
+
   describe '#preload_current_user_availabilities' do
     it 'returns empty hash when no matches' do
       Match.destroy_all


### PR DESCRIPTION
## Summary
- P8 in `docs/code_quality_todo.md`: `PrefetchMatchData#build_availability_counts_hash` ran two queries **per match** — `match.match_availabilities.where(available: true).pluck(:user_id)` and `match.aways.where(...).count` (itself joining users/participations/absences) — ~40 extra queries for 20 matches, defeating the point of the prefetch concern.
- Availability data is now fetched once via `pluck(:match_id, :user_id, :available)` scoped to the section's players and grouped in Ruby; per-match counts and the "marked available but away" subtraction are computed from that.
- The existing single absence fetch is kept as rows and intersected per match in memory (`absences_covering`, same `start_at <= start && end_at >= end` predicate as the old `match.aways`).
- Behavior note: the away-while-available subtraction is now consistently scoped to section players — the availability counts it is subtracted from were already scoped that way.

## Test plan
- [x] New regression spec counts `sql.active_record` SELECTs touching `match_availabilities` across 10 matches (≤3); verified it **fails** against the old implementation
- [x] All existing `PrefetchMatchData` behavior specs pass unchanged (availability/absence mixes, no-response counts)
- [x] `bin/rspec` — 678 examples, 0 failures
- [x] `bin/rubocop` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)