### PR TITLE
Add P13: bullet, rubocop-performance and strong_migrations guardrails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 plugins:
+  - rubocop-performance
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-rspec
@@ -25,3 +26,7 @@ Rails/I18nLocaleTexts:
 
 RSpec/IndexedLet:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - "config/environments/*.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'slim'
 gem 'sprockets-rails'
 gem 'stimulus-rails'
 gem 'string-similarity'
+gem 'strong_migrations'
 gem 'switch_user'
 gem 'tailwindcss-rails', '~> 4.6'
 gem 'turbo-rails'
@@ -66,6 +67,7 @@ gem 'image_processing', '~> 2.0'
 
 group :development, :test do
   gem 'brakeman', require: false
+  gem 'bullet'
   gem 'debug'
   gem 'dotenv-rails'
   gem 'factory_bot_rails'
@@ -75,6 +77,7 @@ group :development, :test do
   gem 'rubocop', require: false
   gem 'rubocop-capybara', require: false
   gem 'rubocop-factory_bot', require: false
+  gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
   gem 'rubocop-rspec_rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,9 @@ GEM
     brakeman (8.0.5)
       racc
     builder (3.3.0)
+    bullet (8.1.3)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.40.0)
       addressable
       matrix
@@ -488,6 +491,10 @@ GEM
     rubocop-factory_bot (2.28.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
+    rubocop-performance (1.26.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
     rubocop-rails (2.35.5)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
@@ -584,6 +591,8 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     string-similarity (2.1.0)
+    strong_migrations (2.8.0)
+      activerecord (>= 7.2)
     switch_user (1.5.4)
     tailwindcss-rails (4.6.0)
       railties (>= 7.0.0)
@@ -609,6 +618,7 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
+    uniform_notifier (1.18.0)
     uri (1.1.1)
     useragent (0.16.11)
     warden (1.2.9)
@@ -645,6 +655,7 @@ DEPENDENCIES
   bcrypt
   bootsnap
   brakeman
+  bullet
   capybara
   capybara-selenium
   colorist
@@ -685,6 +696,7 @@ DEPENDENCIES
   rubocop
   rubocop-capybara
   rubocop-factory_bot
+  rubocop-performance
   rubocop-rails
   rubocop-rspec
   rubocop-rspec_rails
@@ -707,6 +719,7 @@ DEPENDENCIES
   stackprof
   stimulus-rails
   string-similarity
+  strong_migrations
   switch_user
   tailwindcss-rails (~> 4.6)
   timecop

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -4,7 +4,7 @@ class CalendarsController < ApplicationController
   before_action :find_calendar_by_id, only: %i[edit update]
 
   def index
-    @calendars = Calendar.order(season_id: :DESC)
+    @calendars = Calendar.includes(:season).order(season_id: :DESC)
     @calendar = Calendar.new(season: Season.current)
   end
 

--- a/app/controllers/championships_controller.rb
+++ b/app/controllers/championships_controller.rb
@@ -8,6 +8,7 @@ class ChampionshipsController < ApplicationController
   def index
     scope = current_section ? current_section.championships : Championship
     @championships = scope.where(season: Season.current).order(created_at: :desc)
+    @match_counts_by_championship_id = Match.where(championship_id: @championships.unscope(:order).ids).group(:championship_id).count
   end
 
   def show

--- a/app/controllers/concerns/prefetch_match_data.rb
+++ b/app/controllers/concerns/prefetch_match_data.rb
@@ -46,7 +46,7 @@ module PrefetchMatchData
   def section_player_absences(section_player_ids)
     return [] if section_player_ids.empty?
 
-    min_match_time = @next_matches.map(&:calculated_start_datetime).compact.min
+    min_match_time = @next_matches.filter_map(&:calculated_start_datetime).min
     max_match_time = @next_matches.filter_map { |m| m.end_datetime || m.day&.period_end_date }.max
     return [] if min_match_time.blank? || max_match_time.blank?
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,9 +4,9 @@ class Group < ApplicationRecord
   belongs_to :section
   belongs_to :season
 
-  has_many :group_memberships, dependent: :destroy
+  has_many :group_memberships, dependent: :delete_all
   has_many :users, through: :group_memberships
-  has_many :group_trainings, dependent: :destroy
+  has_many :group_trainings, dependent: :delete_all
   has_many :trainings, through: :group_trainings
 
   validates :name, presence: true

--- a/app/services/fdm_parser_service.rb
+++ b/app/services/fdm_parser_service.rb
@@ -75,7 +75,7 @@ class FdmParserService
   end
 
   def parse_player_line(line, positions)
-    licence_match = line.match(/(#{LICENCE_PATTERN})/)
+    licence_match = line.match(/(#{LICENCE_PATTERN})/o)
     return nil if licence_match.nil?
 
     licence = licence_match[1]

--- a/app/services/ffhb_service.rb
+++ b/app/services/ffhb_service.rb
@@ -58,47 +58,47 @@ class FfhbService # rubocop:disable Metrics/ClassLength
 
   def fetch_competition_details(competition_key)
     fetch_smartfire_attributes(
-      "https://www.ffhandball.fr/competitions/saison-2025-2026-21/departemental/#{competition_key.gsub('_', '-')}/",
+      "https://www.ffhandball.fr/competitions/saison-2025-2026-21/departemental/#{competition_key.tr('_', '-')}/",
       'competitions---poule-selector'
     )
   end
 
   def fetch_competition_stats(competition_key, _phase_id, code_pool)
     fetch_smartfire_attributes(
-      "https://www.ffhandball.fr/competitions/saison-2025-2026-21/departemental/#{competition_key.gsub('_',
-                                                                                                       '-')}/poule-#{code_pool}/statistiques/",
+      "https://www.ffhandball.fr/competitions/saison-2025-2026-21/departemental/#{competition_key.tr('_',
+                                                                                                     '-')}/poule-#{code_pool}/statistiques/",
       'competitions---stats-joueurs'
     )
   end
 
   def fetch_pool_details(competition_key, code_pool)
     fetch_smartfire_attributes(
-      "https://www.ffhandball.fr/competitions/saison-2025-2026-21/departemental/#{competition_key.gsub('_',
-                                                                                                       '-')}/poule-#{code_pool}/",
+      "https://www.ffhandball.fr/competitions/saison-2025-2026-21/departemental/#{competition_key.tr('_',
+                                                                                                     '-')}/poule-#{code_pool}/",
       'competitions---poule-selector'
     )
   end
 
   def fetch_journee_details(competition_key, code_pool, journee_number)
     fetch_smartfire_attributes(
-      "https://www.ffhandball.fr/competitions/saison-2025-2026-21/departemental/#{competition_key.gsub('_',
-                                                                                                       '-')}/poule-#{code_pool}/journee-#{journee_number}/",
+      "https://www.ffhandball.fr/competitions/saison-2025-2026-21/departemental/#{competition_key.tr('_',
+                                                                                                     '-')}/poule-#{code_pool}/journee-#{journee_number}/",
       'competitions---rencontre-list'
     )
   end
 
   def fetch_match_details(competition_key, code_pool, rencontre_id)
     fetch_smartfire_attributes(
-      "https://www.ffhandball.fr/competitions/saison-2025-2026-21/departemental/#{competition_key.gsub('_',
-                                                                                                       '-')}/poule-#{code_pool}/rencontre-#{rencontre_id}/",
+      "https://www.ffhandball.fr/competitions/saison-2025-2026-21/departemental/#{competition_key.tr('_',
+                                                                                                     '-')}/poule-#{code_pool}/rencontre-#{rencontre_id}/",
       'competitions---rematch'
     )
   end
 
   def fetch_rencontre_salle(competition_key, code_pool, rencontre_id)
     fetch_smartfire_attributes(
-      "https://www.ffhandball.fr/competitions/saison-2025-2026-21/departemental/#{competition_key.gsub('_',
-                                                                                                       '-')}/poule-#{code_pool}/rencontre-#{rencontre_id}/",
+      "https://www.ffhandball.fr/competitions/saison-2025-2026-21/departemental/#{competition_key.tr('_',
+                                                                                                     '-')}/poule-#{code_pool}/rencontre-#{rencontre_id}/",
       'competitions---rencontre-salle'
     )
   end

--- a/app/views/championships/index.html.slim
+++ b/app/views/championships/index.html.slim
@@ -18,7 +18,7 @@ div class="sm:flex sm:items-center"
           p class="text-sm/6 font-semibold text-gray-900"
             = link_to championship.name, link_url, class: 'hover:text-indigo-600'
           div class="mt-1 flex items-center gap-x-2 text-xs/5 text-gray-500"
-            p class="whitespace-nowrap" = t('views.counts.match', count: championship.matches.count)
+            p class="whitespace-nowrap" = t('views.counts.match', count: @match_counts_by_championship_id.fetch(championship.id, 0))
             svg viewBox="0 0 2 2" class="size-0.5 fill-current"
               circle r="1" cx="1" cy="1"
             p class="truncate" = t('views.counts.team', count: championship.teams.count)

--- a/app/views/channels/show.html.slim
+++ b/app/views/channels/show.html.slim
@@ -13,7 +13,7 @@ div class="flex flex-col h-screen overflow-hidden"
           = render @channels
 
     div id="messages" class="grow overflow-auto pb-28 bg-gray-100" data-controller="scroll" data-scroll-target="messages"
-      = render @channel.messages.order(:id)
+      = render @channel.messages.with_rich_text_content.includes(:user).order(:id)
 
       turbo-frame id="message-form"
         div class="fixed bottom-0 pt-2 bg-white w-full"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -76,4 +76,14 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.after_initialize do
+    Bullet.enable = true
+    # unused-eager-loading detection is too noisy (controllers preload for views/specs that do not always consume them)
+    Bullet.unused_eager_loading_enable = false
+    # counter-cache suggestions require schema changes; treat them as advisory only
+    Bullet.counter_cache_enable = false
+    Bullet.bullet_logger = true
+    Bullet.add_footer = true
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -64,4 +64,13 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.after_initialize do
+    Bullet.enable = true
+    # unused-eager-loading detection is too noisy (controllers preload for views/specs that do not always consume them)
+    Bullet.unused_eager_loading_enable = false
+    # counter-cache suggestions require schema changes; treat them as advisory only
+    Bullet.counter_cache_enable = false
+    Bullet.raise = true # raise an error if an N+1 query occurs
+  end
 end

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Only check migrations created after the gem was introduced.
+StrongMigrations.start_after = 20_260_619_094_233
+
+# Longer statement timeouts are fine for this app's small tables; keep the
+# gem defaults for lock timeouts.

--- a/docs/code_quality_todo.md
+++ b/docs/code_quality_todo.md
@@ -156,7 +156,7 @@ E.g. boundary handling of `day.period_start_date`/`period_end_date` differs betw
 
 ## P13 — Tooling: add bullet, rubocop-performance, strong_migrations
 
-- **Status**: todo
+- **Status**: done — added the three gems. `bullet`: enabled in dev (log + page footer) and test (`Bullet.raise = true`, wired into RSpec via `start_request`/`end_request` hooks in `rails_helper.rb`); `unused_eager_loading` and `counter_cache` detectors disabled in both envs (too noisy: controllers legitimately preload for views that specs don't always render, and counter-cache suggestions require schema changes). N+1 detection surfaced and fixed 5 real N+1s: `CalendarsController#index` missing `includes(:season)`; `channels/show` messages missing `includes(:user)` **and** ActionText `with_rich_text_content`; `championships/index` ran a COUNT per championship (now one grouped count in the controller); `Group` join models (`group_memberships`, `group_trainings` — both callback-free) switched from `dependent: :destroy` to `:delete_all`, removing per-group loads on section destroy. `rubocop-performance`: added to the plugins list; auto-corrected 15 offenses (mostly in `FfhbService`). `strong_migrations`: initializer sets `start_after` to the last pre-existing migration. Bullet runs in CI automatically since CI runs the test suite. Branch: `chore/p13-guardrail-gems` (stacked on P12). Note: since Bullet raises in test, any new N+1 fails the suite from now on.
 - **Priority**: 13
 
 **Details**: Three cheap guardrails missing from the Gemfile:

--- a/spec/controllers/application_controller_log_requests_spec.rb
+++ b/spec/controllers/application_controller_log_requests_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ApplicationController do
 
       it 'filters sensitive query string params out of the logged request' do
         logged_line = nil
-        allow(Rails.logger).to receive(:info) { |msg| logged_line = msg if msg =~ /REQ/ }
+        allow(Rails.logger).to receive(:info) { |msg| logged_line = msg if msg.include?('REQ') }
 
         get :index, params: { user_token: 'super-secret-token' }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,6 +39,17 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = Rails.root.join('/spec/fixtures')
 
+  if Bullet.enable?
+    config.before do
+      Bullet.start_request
+    end
+
+    config.after do
+      Bullet.perform_out_of_channel_notifications if Bullet.notification?
+      Bullet.end_request
+    end
+  end
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
## Summary
P13 in `docs/code_quality_todo.md`. **Stacked on #1115 (P12)** — merge order: #1111 → #1113 → #1114 → #1115 → this.

- **bullet** (dev/test): dev logs + page footer; test **raises** on N+1 (RSpec `start_request`/`end_request` hooks in `rails_helper.rb`), so any new N+1 fails CI from now on. The `unused_eager_loading` and `counter_cache` detectors are disabled — the former flags controllers that legitimately preload for views the spec doesn't render, the latter wants schema changes.
- **N+1s bullet surfaced, fixed here**:
  - `CalendarsController#index` — `includes(:season)` (one query per calendar row before)
  - `channels/show` — messages now load with `includes(:user)` and ActionText's `with_rich_text_content` (two queries per message before)
  - `championships/index` — ran `matches.count` per championship; now one grouped count
  - `Group`'s join models (`group_memberships`, `group_trainings`, both callback-free) → `dependent: :delete_all`, removing per-group loads when destroying a section
- **rubocop-performance**: added to `.rubocop.yml` plugins; 15 offenses auto-corrected (mostly `FfhbService`). `config/environments/*` excluded from `Metrics/BlockLength` (the Bullet block pushed dev.rb over).
- **strong_migrations**: initializer sets `start_after` to the last pre-existing migration so only new migrations are checked.

## Test plan
- [x] `bin/rspec` — 697 examples, 0 failures **with Bullet raising on N+1**
- [x] `bin/rubocop` — clean
- [x] Verified each fixed N+1 previously failed under Bullet

🤖 Generated with [Claude Code](https://claude.com/claude-code)