### PR TITLE
Clean P15: small conventions fixes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  extend ActiveSupport::Concern
-
   around_action :log_requests
 
   before_action :set_sentry_context

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -107,7 +107,7 @@ class Match < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def meeting_datetime
-    super || start_datetime&.send(:-, 1.hour)
+    super || (start_datetime && (start_datetime - 1.hour))
   end
 
   def ffhb_sync! # rubocop:disable Metrics/AbcSize,Metrics/MethodLength

--- a/docs/code_quality_todo.md
+++ b/docs/code_quality_todo.md
@@ -181,7 +181,7 @@ E.g. boundary handling of `day.period_start_date`/`period_end_date` differs betw
 
 ## P15 — Cleanup: small conventions fixes
 
-- **Status**: todo
+- **Status**: done — split across three PRs where the fixes naturally belonged. In this branch (`chore/p15-conventions-fixes`): removed the meaningless `extend ActiveSupport::Concern` from `ApplicationController`, and rewrote `Match#meeting_datetime` as `super || (start_datetime && start_datetime - 1.hour)`. Done earlier elsewhere: the duplicated `ChampionshipsController#create` `redirect_with` blocks collapsed when the FFHB flow moved to its own controller (P9, #1112); the `present_for!`/`not_present_for!`/`not_available_for!` "normalize arg to array" boilerplate became `Array.wrap` during the concern extraction (P11, #1114).
 - **Priority**: 15
 
 **Details**: Low-risk one-liners, can be a single PR:


### PR DESCRIPTION
## Summary
P15 in `docs/code_quality_todo.md` — the two items not already covered elsewhere:

- `ApplicationController`: removed `extend ActiveSupport::Concern` — meant for modules, meaningless on a class.
- `Match#meeting_datetime`: `start_datetime&.send(:-, 1.hour)` → `super || (start_datetime && (start_datetime - 1.hour))`.

Already done where they naturally belonged:
- `ChampionshipsController#create` duplicated `redirect_with` blocks — collapsed by the FFHB controller split in #1112 (P9).
- `present_for!`/`not_present_for!`/`not_available_for!` array normalization — replaced with `Array.wrap` in #1114 (P11).

## Test plan
- [x] `bin/rspec` — 677 examples, 0 failures
- [x] `bin/rubocop` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)